### PR TITLE
feat: Add updateUserStoryStatus tool

### DIFF
--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -6,7 +6,7 @@
 // Import all tool modules
 import { authenticateTool } from './authTools.js';
 import { listProjectsTool, getProjectTool } from './projectTools.js';
-import { listUserStoriesTool, getUserStoryTool, createUserStoryTool, assignUserStoryToSprintTool } from './userStoryTools.js';
+import { listUserStoriesTool, getUserStoryTool, createUserStoryTool, assignUserStoryToSprintTool, updateUserStoryStatusTool } from './userStoryTools.js';
 import { createTaskTool } from './taskTools.js';
 import { listIssuesTool, getIssueTool, createIssueTool, addIssueToSprintTool, assignIssueTool, updateIssueStatusTool } from './issueTools.js';
 import { listSprintsTool, getSprintStatsTool, createSprintTool, getIssuesBySprintTool, getMilestoneTool } from './sprintTools.js';
@@ -38,7 +38,8 @@ export const toolRegistry = {
     listUserStoriesTool,
     getUserStoryTool,
     createUserStoryTool,
-    assignUserStoryToSprintTool
+    assignUserStoryToSprintTool,
+    updateUserStoryStatusTool
   ],
   
   // Task tools


### PR DESCRIPTION
## Summary

This PR adds the ability to update user story status via MCP, mirroring the existing `updateIssueStatus` functionality.

**Problem:** The package has `updateIssueStatus` for issues but no equivalent for user stories. Users cannot change user story status (e.g., to "Done") via MCP.

**Solution:** Add `updateUserStoryStatus` tool that:
- Takes `userStoryId` and `status` name (e.g., "Done", "In Progress")
- Looks up status ID from project's configured statuses
- Uses existing `taigaService.updateUserStory()` and `getUserStoryStatuses()` methods
- Returns formatted success message with updated story details
- Provides helpful error with available statuses if invalid name given

## Changes

- `src/tools/userStoryTools.js`: Added `updateUserStoryStatusTool` export
- `src/tools/index.js`: Added import and registry entry

## Testing

- All unit tests pass (11/11)
- Tool count increased from 45 to 46

## Example Usage

```javascript
// Update user story #15 to "Done" status
updateUserStoryStatus({ userStoryId: "15", status: "Done" })

// Returns:
// Successfully updated status for user story #15 to "Done".
// User Story Details:
// - Subject: Migrate Vault to Production Mode
// - Project: Infrastructure Remediation
// - New Status: Done
// - Assigned to: Unassigned
// - Sprint: No Sprint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)