### PR TITLE
Fix: linkStoryToEpic uses correct Taiga API endpoint

### DIFF
--- a/src/taigaService.js
+++ b/src/taigaService.js
@@ -1128,14 +1128,9 @@ export class TaigaService {
     try {
       const client = await createAuthenticatedClient();
       
-      // Get current User Story to get version for update
-      const currentStory = await client.get(`${API_ENDPOINTS.USER_STORIES}/${userStoryId}`);
-      const updateData = {
-        epic: epicId,
-        version: currentStory.data.version
-      };
-      
-      const response = await client.patch(`${API_ENDPOINTS.USER_STORIES}/${userStoryId}`, updateData);
+      const response = await client.post(`${API_ENDPOINTS.EPICS}/${epicId}/related_userstories`, {
+        user_story: userStoryId
+      });
       return response.data;
     } catch (error) {
       console.error('Failed to link story to epic:', error.message);


### PR DESCRIPTION
Fixes #5: Correct Taiga API endpoint for linking user story to epic.

The `linkStoryToEpic` tool was directly patching the `epic` field on the user story, which Taiga API does not correctly persist. 
This PR changes it to use the correct `POST /api/v1/epics/{epicId}/related_userstories` endpoint as expected by the official Taiga API.

Wallet for bounty payout: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana)